### PR TITLE
avoid react warning about input becaming controlled

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -58,7 +58,9 @@ var Switch = function (_React$Component) {
       _this.setChecked();
     };
 
-    _this.state = {};
+    _this.state = {
+      checked: props.checked
+    };
     return _this;
   }
 
@@ -72,12 +74,6 @@ var Switch = function (_React$Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       var input = this.elCheckbox;
-      var checked = this.props.checked;
-      /* eslint-disable */
-      this.setState({
-        checked: checked
-      });
-      /* eslint-enable */
       /* eslint-disable no-undef, no-new */
       new _mohithgSwitchery2.default(input, this.props.options);
       /* eslint-enable no-new, no-undef */
@@ -142,7 +138,9 @@ var Switch = function (_React$Component) {
           },
           checked: this.state.checked,
           type: 'checkbox',
-          defaultChecked: this.props.checked
+          onChange: function onChange() {
+            return null;
+          }
         })
       );
     }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,9 @@ class Switch extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      checked: props.checked,
+    };
   }
 
   /**
@@ -23,12 +25,6 @@ class Switch extends React.Component {
    */
   componentDidMount() {
     const input = this.elCheckbox;
-    const checked = this.props.checked;
-    /* eslint-disable */
-    this.setState({
-      checked,
-    });
-    /* eslint-enable */
     /* eslint-disable no-undef, no-new */
     new Switchery(input, this.props.options);
     /* eslint-enable no-new, no-undef */
@@ -89,6 +85,7 @@ class Switch extends React.Component {
           ref={elCheckbox => { this.elCheckbox = elCheckbox; }}
           checked={this.state.checked}
           type="checkbox"
+          onChange={() => null}
         />
       </div>
     );


### PR DESCRIPTION
`checked` state is initialized in `componentWillReceiveProps`, so in first render its value is still undefined.
This causes input to go from uncontrolled to controlled, and so React emits a warning. This is easily resolvable by initing checked state before first render